### PR TITLE
🚧 パーセンテージのロジック変更

### DIFF
--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -11,6 +11,7 @@ export const Skills = () => {
         <div className="container">
           <div className="heading">
             <h2>Skills</h2>
+            <p>リポジトリに占める言語の割合</p>
           </div>
 
           <div className="skills-container">

--- a/src/customHooks/useSkills.ts
+++ b/src/customHooks/useSkills.ts
@@ -16,10 +16,11 @@ type Language = {
 export type UseSkills = [
   sortedLanguageList: () => LanguageState[] | undefined,
   fetchRequestState: string | undefined,
-  converseCountToPercentage: (languageCount: number) => number
+  converseCountToPercentage: (
+    languageCount: number,
+    uniqueLanguageList: string[]
+  ) => number
 ];
-
-const DEFAULT_MAX_PERCENTAGE = 100;
 const LANGUAGE_COUNT_BASE = 10;
 
 export function useSkills(): UseSkills {
@@ -56,12 +57,14 @@ export function useSkills(): UseSkills {
     dispatch({ type: "actionTypes.fetch" });
   }, []);
 
+  // const notNullLanguageList = (allLanguageList: string[]) => {
+  //   allLanguageList.filter((language: string) => language != null);
+  // };
   const generateLanguageCountObj = (allLanguageList: string[]) => {
     const notNullLanguageList = allLanguageList.filter(
       (language: string) => language != null
     );
     const uniqueLanguageList = [...new Set(notNullLanguageList)];
-
     return uniqueLanguageList.map((item) => {
       return {
         language: item,
@@ -70,12 +73,21 @@ export function useSkills(): UseSkills {
     });
   };
 
+  // const converseCountToPercentage = (languageCount: number): number => {
+  //   if (languageCount > LANGUAGE_COUNT_BASE) {
+  //     return DEFAULT_MAX_PERCENTAGE;
+  //   }
+  //   return languageCount * LANGUAGE_COUNT_BASE;
+  // };
+
   const converseCountToPercentage = (languageCount: number): number => {
-    if (languageCount > LANGUAGE_COUNT_BASE) {
-      return DEFAULT_MAX_PERCENTAGE;
+    if (languageCount > 0) {
+      console.log((languageCount / notNullLanguageList.length) * 100);
+      return (languageCount / notNullLanguageList.length) * 100;
     }
-    return languageCount * LANGUAGE_COUNT_BASE;
+    return LANGUAGE_COUNT_BASE;
   };
+
   const sortedLanguageList = () =>
     state.languageList?.sort(
       (firstLang, nextLang) => nextLang.count - firstLang.count

--- a/src/customHooks/useSkills.ts
+++ b/src/customHooks/useSkills.ts
@@ -16,10 +16,7 @@ type Language = {
 export type UseSkills = [
   sortedLanguageList: () => LanguageState[] | undefined,
   fetchRequestState: string | undefined,
-  converseCountToPercentage: (
-    languageCount: number,
-    uniqueLanguageList: string[]
-  ) => number
+  converseCountToPercentage: (languageCount: number) => number
 ];
 const LANGUAGE_COUNT_BASE = 10;
 
@@ -57,14 +54,12 @@ export function useSkills(): UseSkills {
     dispatch({ type: "actionTypes.fetch" });
   }, []);
 
-  // const notNullLanguageList = (allLanguageList: string[]) => {
-  //   allLanguageList.filter((language: string) => language != null);
-  // };
   const generateLanguageCountObj = (allLanguageList: string[]) => {
     const notNullLanguageList = allLanguageList.filter(
       (language: string) => language != null
     );
     const uniqueLanguageList = [...new Set(notNullLanguageList)];
+    // 重複値をとりにぞいた新たな配列を生成する。['JavaScript', 'JavaScript', 'Ruby']を['JavaScript','Ruby']にする
     return uniqueLanguageList.map((item) => {
       return {
         language: item,
@@ -73,18 +68,15 @@ export function useSkills(): UseSkills {
     });
   };
 
-  // const converseCountToPercentage = (languageCount: number): number => {
-  //   if (languageCount > LANGUAGE_COUNT_BASE) {
-  //     return DEFAULT_MAX_PERCENTAGE;
-  //   }
-  //   return languageCount * LANGUAGE_COUNT_BASE;
+  // const notNullLanguageList = (allLanguageList: string[]) => {
+  //   allLanguageList.filter((language: string) => language != null);
   // };
 
   const converseCountToPercentage = (languageCount: number): number => {
     if (languageCount > 0) {
-      console.log((languageCount / notNullLanguageList.length) * 100);
-      return (languageCount / notNullLanguageList.length) * 100;
+      return Math.round((languageCount / 28) * 100);
     }
+
     return LANGUAGE_COUNT_BASE;
   };
 
@@ -94,5 +86,13 @@ export function useSkills(): UseSkills {
     );
   // state.languageListには{language: 'TypeScript', count: 8},{language: 'Ruby', count: 5} が入ってくる
   // countが多い、降順にならべられる。
+
   return [sortedLanguageList, state.requestState, converseCountToPercentage];
 }
+
+// const converseCountToPercentage = (languageCount: number): number => {
+//   if (languageCount > LANGUAGE_COUNT_BASE) {
+//     return DEFAULT_MAX_PERCENTAGE;
+//   }
+//   return languageCount * LANGUAGE_COUNT_BASE;
+// };


### PR DESCRIPTION
### 変更点

- パーセンテージのロジック変更
リポジトリにある言語のパーセンテージが表示されているロジックが10以上だったら100%、10以下だったらその数掛ける10するという表示になっているので、ユーザーがわかりにくい表示になっている。

### 実現したいこと
言語のリポジトリ内の使用比率を出せるようにする。